### PR TITLE
Fix `each-subpath` returning an empty string when used with a root path

### DIFF
--- a/filesystem.janet
+++ b/filesystem.janet
@@ -18,8 +18,9 @@
   [path func]
   (def indices (string/find-all path/sep path))
   (each idx indices
-    (def subpath (string/slice path 0 idx))
-    (func subpath))
+    (if (not= idx 0)
+      (let [subpath (string/slice path 0 idx)]
+        (func subpath))))
   (func path))
 
 # ------------------------------------------------------------------------------

--- a/test/test.janet
+++ b/test/test.janet
@@ -47,6 +47,14 @@
   (aeq (filesystem/list-all-files "tmp/files/")
       @["tmp/files/subdir/world.txt" "tmp/files/hello.txt"])))
 
+# list-all-files with absolute paths
+(run-test (fn []
+  (def abs-files (path/abspath "tmp/files/"))
+  (filesystem/create-file "tmp/files/hello.txt")
+  (filesystem/create-file "tmp/files/subdir/world.txt")
+  (aeq (filesystem/list-all-files abs-files)
+      @[(path/join abs-files "subdir/world.txt") (path/join abs-files "hello.txt")])))
+
 # create-directories
 (run-test (fn []
   (def test-dirs "tmp/a/b/c")
@@ -90,6 +98,16 @@
 (run-test (fn []
   (def src "tmp/a/b/c/src.txt")
   (def dst "tmp/a/b/c/dst.txt")
+  (def test-string "Hello")
+  (filesystem/write-file src test-string)
+  (filesystem/copy-file src dst)
+  (aet (filesystem/exists? dst))
+  (aeq (string (filesystem/read-file dst)) test-string)))
+
+# copy-file with absolute paths
+(run-test (fn []
+  (def src (path/abspath "tmp/a/b/c/src.txt"))
+  (def dst (path/abspath "tmp/a/b/c/dst.txt"))
   (def test-string "Hello")
   (filesystem/write-file src test-string)
   (filesystem/copy-file src dst)


### PR DESCRIPTION
Because it looks for any path separators, including the leading one in an absolute path, if you pass in an absolute path it will return `""` as the first element of the array.

This PR fixes that and also adds some test cases to make sure it works.