### PR TITLE
Make error message on test case failure more helpful

### DIFF
--- a/test/test.janet
+++ b/test/test.janet
@@ -1,11 +1,12 @@
 (import ../filesystem :as filesystem)
+(import path)
 
 (defn aeq
   "assert equal"
   [x y]
   (unless (deep= x y)
     (with-dyns [:out stderr]
-      (print "expected " x " to equal " y))
+      (printf "expected %m to equal %m" x y))
     (os/exit 1)))
 
 (defn aet


### PR DESCRIPTION
Use `%m` to print the items that don't match, instead of the raw string representation which isn't very helpful for arrays.